### PR TITLE
Add Image.transparent(enabled: Bool)

### DIFF
--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -21,6 +21,13 @@ public class Image {
 		return Size(width: internalImage.pointee.sx, height: internalImage.pointee.sy)
 	}
 
+	public var transparent: Bool = false {
+		didSet {
+			gdImageSaveAlpha(internalImage, transparent ? 1 : 0)
+			gdImageAlphaBlending(internalImage, transparent ? 0 : 1)
+		}
+	}
+
 	public init?(width: Int, height: Int) {
 		internalImage = gdImageCreateTrueColor(Int32(width), Int32(height))
 	}
@@ -192,11 +199,6 @@ public class Image {
 
 	public func desaturate() {
 		gdImageGrayScale(internalImage)
-	}
-
-	public func transparent(enabled: Bool) {
-		gdImageSaveAlpha(internalImage, enabled ? 1 : 0)
-		gdImageAlphaBlending(internalImage, enabled ? 0 : 1)
 	}
 
 	deinit {

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -194,6 +194,11 @@ public class Image {
 		gdImageGrayScale(internalImage)
 	}
 
+	public func transparent(enabled: Bool) {
+		gdImageSaveAlpha(internalImage, enabled ? 1 : 0)
+		gdImageAlphaBlending(internalImage, enabled ? 0 : 1)
+	}
+
 	deinit {
 		// always destroy our internal image resource
 		gdImageDestroy(internalImage)


### PR DESCRIPTION
The `Data` object exported from `Image.export()` is not transparent, so I added `Image.transparent(enabled: Bool)` to call it before export.