### PR TITLE
Free memory of image pointer after export

### DIFF
--- a/Sources/Format.swift
+++ b/Sources/Format.swift
@@ -105,7 +105,9 @@ extension LibGdParametrizableExportFormatter {
         guard let bytesPtr = exportFunction(imagePtr, &size, exportParameters) else {
             throw Error.invalidFormat
         }
-        return Data(bytes: bytesPtr, count: Int(size))
+        return Data(bytesNoCopy: bytesPtr,
+                    count: Int(size),
+                    deallocator: .custom({ ptr, _ in gdFree(ptr) }))
     }
 }
 


### PR DESCRIPTION
When exporting we were copying the image bytes over to a `Data` instance but never actually freed the original data.

This PR does not copy the bytes into a `Data` instance but instead creates a `Data` instance from the given exported bytes and adds a custom `Data.Deallocator` that calls `gdFree` to free the memory after usage.

Fixes #17.

Alternatively, we could also copy the bytes as before and just add a call to `gdFree` in the end:

```swift
defer {
  gdFree(bytesPtr)
}
```

But this PR avoids the additional copy.