### PR TITLE
`Image` now implements gd’s `gdImageTrueColorToPalette()` method

### DIFF
--- a/Sources/SwiftGD/Error.swift
+++ b/Sources/SwiftGD/Error.swift
@@ -5,8 +5,10 @@ import Foundation
 /// - invalidFormat: Image raster format mismatch on import/export
 /// - invalidImage: Contains the reason this error was thrown.
 /// - invalidColor: Contains the reason this error was thrown.
+/// - invalidMaxColors: Asserts sane values for creating indexed Images
 public enum Error: Swift.Error {
     case invalidFormat
     case invalidImage(reason: String) // The reason this error was thrown
     case invalidColor(reason: String) // The reason this error was thrown.
+    case invalidMaxColors(reason: String)
 }

--- a/Sources/SwiftGD/Image.swift
+++ b/Sources/SwiftGD/Image.swift
@@ -206,6 +206,18 @@ public class Image {
     public func desaturate() {
         gdImageGrayScale(internalImage)
     }
+    
+    /// Reduces `Image` to an indexed palatte of colors from larger color spaces.
+    /// Index `Image`s only make sense with 2 or more oclors, and will `throw` nonsense values
+    /// - Parameter numberOfColors: maximum number of colors
+    /// - Parameter shouldDither: true will apply GD’s internal dithering algorithm
+    public func reduceColors(max numberOfColors: Int, shouldDither: Bool = true) throws {
+        guard numberOfColors > 1 else {
+            throw Error.invalidMaxColors(reason: "Indexed images must have at least 2 colors")
+        }
+        let shouldDither: Int32 = shouldDither ? 1 : 0
+        gdImageTrueColorToPalette(internalImage, shouldDither, Int32(numberOfColors))
+    }
 
     deinit {
         // always destroy our internal image resource

--- a/Tests/SwiftGDTests/SwiftGDTests.swift
+++ b/Tests/SwiftGDTests/SwiftGDTests.swift
@@ -2,15 +2,26 @@ import XCTest
 @testable import SwiftGD
 
 class SwiftGDTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-//        XCTAssertEqual(SwiftGD().text, "Hello, World!")
+    func testReduceColors() {
+        let size = 16
+        let imColor = Color.init(red: 0.2,
+                                 green: 0.10,
+                                 blue: 0.77,
+                                 alpha: 1.0)
+        let image = Image(width: size, height: size)
+        image!.fillRectangle(topLeft: Point.zero, bottomRight: Point(x: size, y: size), color: imColor)
+        try! image?.reduceColors(max: 4, shouldDither: false)
+        XCTAssert(image != nil, "ReduceColors without dithering should not destroy Image instance")
+        try! image?.reduceColors(max: 2, shouldDither: true)
+        XCTAssert(image != nil, "ReduceColors while dithering should not destroy Image instance")
+        for ii in -1...1 {
+            XCTAssertThrowsError(try image?.reduceColors(max: ii), "`Image` should throw with insane maxColor values when making indexed `Image`s")
+        }
     }
 
     static var allTests: [(String, (SwiftGDTests) -> () throws -> Void)] {
         return [
-            ("testExample", testExample)
+            ("testReduceColors", testReduceColors)
         ]
     }
 }


### PR DESCRIPTION
This is handy for a project I’m working on. But, I’m sure it’ll be handy for others in the future. GIFs and PNGs can have index color palettes.