### PR TITLE
renderText improvements

### DIFF
--- a/Sources/SwiftGD/Image.swift
+++ b/Sources/SwiftGD/Image.swift
@@ -109,7 +109,7 @@ public class Image {
     ///   - color: The font color.
     ///   - size: The height of the font in typographical points (pt).
     ///   - angle: The angle to rotate the rendered text from the basepoint
-    ///     perspective. Positive angles rotate counter-clockwise.
+    ///     perspective. Positive angles rotate clockwise.
     /// - Returns: The rendered text bounding box. You can use this output to
     ///   render the text off-image first, and then render it again, on the
     ///   image, with the bounding box information (e.g., to center-align the
@@ -132,7 +132,7 @@ public class Image {
         // points in the following order:
         // lower left, lower right, upper right, and upper left corner.
         var boundingBox: [Int32] = .init(repeating: .zero, count: 8)
-        gdImageStringFT(internalImage, &boundingBox, internalColor, fontList, size, angle.radians, Int32(from.x), Int32(from.y), text)
+        gdImageStringFT(internalImage, &boundingBox, internalColor, fontList, size, -angle.radians, Int32(from.x), Int32(from.y), text)
 
         let lowerLeft = Point(x: boundingBox[0], y: boundingBox[1])
         let lowerRight = Point(x: boundingBox[2], y: boundingBox[3])

--- a/Sources/SwiftGD/Image.swift
+++ b/Sources/SwiftGD/Image.swift
@@ -117,7 +117,7 @@ public class Image {
     @discardableResult
     public func renderText(
         _ text: String, from: Point, fontList: [String], color: Color, size: Double, angle: Angle = .zero
-    ) -> (lowerLeft: Point, lowerRight: Point, upperRight: Point, upperLeft: Point) {
+    ) -> (upperLeft: Point, upperRight: Point, lowerRight: Point, lowerLeft: Point) {
         let red = Int32(color.redComponent * 255.0)
         let green = Int32(color.greenComponent * 255.0)
         let blue = Int32(color.blueComponent * 255.0)
@@ -138,7 +138,7 @@ public class Image {
         let lowerRight = Point(x: boundingBox[2], y: boundingBox[3])
         let upperRight = Point(x: boundingBox[4], y: boundingBox[5])
         let upperLeft = Point(x: boundingBox[6], y: boundingBox[7])
-        return (lowerLeft, lowerRight, upperRight, upperLeft)
+        return (upperLeft, upperRight, lowerRight, lowerLeft)
     }
 
     public func fill(from: Point, color: Color) {


### PR DESCRIPTION
As discussed in #29, this PR:

- uses positive angles to rotate the rendered text clockwise
- changes the order of the bounding points returned by the method

Both changes aim to make the API more familiar to Apple platform developers