### PR TITLE
FIX: Image.renderText() in Xcode 12 beta 5

### DIFF
--- a/Sources/SwiftGD/Image.swift
+++ b/Sources/SwiftGD/Image.swift
@@ -123,11 +123,11 @@ public class Image {
         /// - `gdImageStringFT` accepts a semicolon delimited list of fonts.
         /// - `gdImageStringFT` expects pointers to `text` and `fontList` values
         guard !text.isEmpty,
-              !fontList.isEmpty,
-              var fontList = CChar(fontList.joined(separator: ";")),
-              var text = CChar(text) else {
+              !fontList.isEmpty else {
                   return (upperLeft: .zero, upperRight: .zero, lowerRight: .zero, lowerLeft: .zero)
         }
+        var textCChar = text.cString(using: .utf8)
+        var joinedFonts = fontList.joined(separator: ";").cString(using: .utf8)
         let red = Int32(color.redComponent * 255.0)
         let green = Int32(color.greenComponent * 255.0)
         let blue = Int32(color.blueComponent * 255.0)
@@ -139,7 +139,7 @@ public class Image {
         // points in the following order:
         // upper left, upper right, lower right, and lower left corner.
         var boundingBox: [Int32] = .init(repeating: .zero, count: 8)
-        gdImageStringFT(internalImage, &boundingBox, internalColor, &fontList, size, -angle.radians, Int32(from.x), Int32(from.y), &text)
+        gdImageStringFT(internalImage, &boundingBox, internalColor, &joinedFonts!, size, -angle.radians, Int32(from.x), Int32(from.y), &textCChar!)
 
         let lowerLeft = Point(x: boundingBox[0], y: boundingBox[1])
         let lowerRight = Point(x: boundingBox[2], y: boundingBox[3])

--- a/Sources/SwiftGD/Image.swift
+++ b/Sources/SwiftGD/Image.swift
@@ -123,11 +123,11 @@ public class Image {
         /// - `gdImageStringFT` accepts a semicolon delimited list of fonts.
         /// - `gdImageStringFT` expects pointers to `text` and `fontList` values
         guard !text.isEmpty,
-              !fontList.isEmpty else {
+              !fontList.isEmpty,
+              var textCChar = text.cString(using: .utf8),
+              var joinedFonts = fontList.joined(separator: ";").cString(using: .utf8) else {
                   return (upperLeft: .zero, upperRight: .zero, lowerRight: .zero, lowerLeft: .zero)
         }
-        var textCChar = text.cString(using: .utf8)
-        var joinedFonts = fontList.joined(separator: ";").cString(using: .utf8)
         let red = Int32(color.redComponent * 255.0)
         let green = Int32(color.greenComponent * 255.0)
         let blue = Int32(color.blueComponent * 255.0)
@@ -139,7 +139,7 @@ public class Image {
         // points in the following order:
         // upper left, upper right, lower right, and lower left corner.
         var boundingBox: [Int32] = .init(repeating: .zero, count: 8)
-        gdImageStringFT(internalImage, &boundingBox, internalColor, &joinedFonts!, size, -angle.radians, Int32(from.x), Int32(from.y), &textCChar!)
+        gdImageStringFT(internalImage, &boundingBox, internalColor, &joinedFonts, size, -angle.radians, Int32(from.x), Int32(from.y), &textCChar)
 
         let lowerLeft = Point(x: boundingBox[0], y: boundingBox[1])
         let lowerRight = Point(x: boundingBox[2], y: boundingBox[3])

--- a/Tests/SwiftGDTests/ImageTests.swift
+++ b/Tests/SwiftGDTests/ImageTests.swift
@@ -2,28 +2,66 @@ import XCTest
 @testable import SwiftGD
 
 class TestImage: XCTestCase {
-    private func assertEmptyBounds(for resultValues: Mirror.Child?) {
-        guard let resultValues = resultValues?.value as? (upperLeft: Point, upperRight: Point, lowerRight: Point, lowerLeft: Point) else {
-            XCTFail("Not a valid render result")
-            return
+    /// Trying to create a list that *should* have at least
+    /// one font for most Swift-compatible platforms.
+    /// NOTE: Tests might fail on platforms that don’t have
+    /// one of these fonts installed. E.g.: Docker images
+    internal static let fontList = [
+        "SFCompact",
+        "ArialMT",
+        "Arial",
+        "Roboto",
+        "Ubuntu",
+        "Noto",
+        "Noto Sans",
+        "SSTPro-Roman"
+    ]
+
+    func testRenderText() throws {
+        guard let image = Image(width: 640, height: 480) else {
+            throw Error.invalidImage(reason: "Could not initialize image")
         }
-        XCTAssertEqual(resultValues.upperLeft, Point.zero)
-        XCTAssertEqual(resultValues.upperRight, Point.zero)
-        XCTAssertEqual(resultValues.lowerRight, Point.zero)
-        XCTAssertEqual(resultValues.lowerLeft, Point.zero)
+        let basepoint = Point(x: 320, y: 240)
+        let renderBounds = image.renderText(
+            "SwiftGD",
+            from: basepoint,
+            fontList: Self.fontList,
+            color: .red,
+            size: 50,
+            angle: .degrees(-15)
+        )
+
+        XCTAssertFalse(try isEmptyBounds(for: renderBounds), "When text is rendered, it returns NON-zero Points")
     }
-    
-    func testRenderText() {
-        let image = Image(width: 640, height: 480)
-        let render = image?.renderText("", from: .zero, fontList: ["Arial", "Ubuntu", "Roboto"], color: .black, size: 18.0)
-        let mirror = render.customMirror
-        let result = mirror.children.first
-        
-        switch result {
-        case .some(let child):
-            assertEmptyBounds(for: child)
-        case .none:
-            XCTFail("Did not get expected return type")
+
+    func testRenderEmptyText() throws {
+        guard let image = Image(width: 640, height: 480) else {
+            throw Error.invalidImage(reason: "Could not initialize image")
+        }
+        let renderBounds = image.renderText("", from: .zero, fontList: ["Arial", "Ubuntu", "Roboto"], color: .black, size: 18.0)
+
+        XCTAssertTrue(try isEmptyBounds(for: renderBounds), "Empty `text` values return tuple of zero-value Points")
+    }
+
+    func testRenderEmptyFontList() throws {
+        guard let image = Image(width: 640, height: 480) else {
+            throw Error.invalidImage(reason: "Could not create image")
+        }
+        let renderBounds = image.renderText("Hello, World", from: .zero, fontList: [], color: .white, size: 18.0)
+
+        XCTAssertTrue(try isEmptyBounds(for: renderBounds), "Empty fontLists return tuple of zero-value Points")
+    }
+}
+
+extension TestImage {
+    private func isEmptyBounds(for resultValues: (upperLeft: Point, upperRight: Point, lowerRight: Point, lowerLeft: Point)) throws -> Bool {
+        return [
+            resultValues.upperLeft,
+            resultValues.upperRight,
+            resultValues.lowerRight,
+            resultValues.lowerLeft
+        ].allSatisfy {
+            $0 == .zero
         }
     }
 }

--- a/Tests/SwiftGDTests/ImageTests.swift
+++ b/Tests/SwiftGDTests/ImageTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import SwiftGD
+
+class TestImage: XCTestCase {
+    private func assertEmptyBounds(for resultValues: Mirror.Child?) {
+        guard let resultValues = resultValues?.value as? (upperLeft: Point, upperRight: Point, lowerRight: Point, lowerLeft: Point) else {
+            XCTFail("Not a valid render result")
+            return
+        }
+        XCTAssertEqual(resultValues.upperLeft, Point.zero)
+        XCTAssertEqual(resultValues.upperRight, Point.zero)
+        XCTAssertEqual(resultValues.lowerRight, Point.zero)
+        XCTAssertEqual(resultValues.lowerLeft, Point.zero)
+    }
+    
+    func testRenderText() {
+        let image = Image(width: 640, height: 480)
+        let render = image?.renderText("", from: .zero, fontList: ["Arial", "Ubuntu", "Roboto"], color: .black, size: 18.0)
+        let mirror = render.customMirror
+        let result = mirror.children.first
+        
+        switch result {
+        case .some(let child):
+            assertEmptyBounds(for: child)
+        case .none:
+            XCTFail("Did not get expected return type")
+        }
+    }
+}


### PR DESCRIPTION
Adding `Image.renderText()` is great work. 
But the `renderText` method should pass pointers instead of values to gdImageStringFT. In fact, this causes compiler Errors in Xcode 12 Beta 5 (Swift 5.5).

This PR fixes these errors.

Additional info:
(swiftlang-1300.0.20.104 clang-1300.0.21.1)