### PR TITLE
Add ability to draw an `Image` into another `Image`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ SwiftGD wraps GD inside classes to make it easier to use, and provides the follo
 - Cropping at a location and size.
 - Flood filling a color from a coordinate.
 - Drawing lines
+- Drawing images
 - Reading and writing individual pixels.
 - Stroking and filling ellipses and rectangles.
 - Flipping images horizontally and vertically.
@@ -106,7 +107,7 @@ To crop an image, call its `cropped(to:)` method, passing in the `Rectangle` tha
 
 ## Drawing shapes, colors and images
 
-There are eight methods you can use to draw into your images:
+There are nine methods you can use to draw into your images:
 
 - `fill(from:color:)` performs a flood fill from a `Point` on your image using the `Color` you specify.
 - `drawLine(from:to:color:)` draws a line between the `to` and `from` parameters (both instances of `Point`) in the `Color` you specify.

--- a/README.md
+++ b/README.md
@@ -104,12 +104,13 @@ To crop an image, call its `cropped(to:)` method, passing in the `Rectangle` tha
 
 
 
-## Drawing shapes and colors
+## Drawing shapes, colors and images
 
 There are eight methods you can use to draw into your images:
 
 - `fill(from:color:)` performs a flood fill from a `Point` on your image using the `Color` you specify.
 - `drawLine(from:to:color:)` draws a line between the `to` and `from` parameters (both instances of `Point`) in the `Color` you specify.
+- `drawImage(_:at:)` draws an `Image` at the specified `Point` (or just top left if `at` is omitted).
 - `set(pixel:to:)` sets a pixel at a specific `Point` to the `Color` you specify.
 - `get(pixel:)` returns the `Color` value of a pixel at a specific `Point`.
 - `strokeEllipse(center:size:color:)` draws an empty ellipse at the center `Point`, with the `Size` and `Color` you specify.

--- a/Sources/SwiftGD/Image.swift
+++ b/Sources/SwiftGD/Image.swift
@@ -193,6 +193,15 @@ public class Image {
         gdImageLine(internalImage, Int32(from.x), Int32(from.y), Int32(to.x), Int32(to.y), internalColor)
     }
 
+    public func drawImage(_ image:Image, at topLeft: Point = .zero) {
+        let width = Int32(self.size.width - topLeft.x)
+        let height = Int32(self.size.height - topLeft.y)
+        let dst_x = Int32(topLeft.x)
+        let dst_y = Int32(topLeft.y)
+
+        gdImageCopy(internalImage, image.internalImage, dst_x, dst_y, 0, 0, width, height)
+    }
+
     public func set(pixel: Point, to color: Color) {
         let red = Int32(color.redComponent * 255.0)
         let green = Int32(color.greenComponent * 255.0)


### PR DESCRIPTION
`gdImageCopy` previously wasn't exposed to consumers of the SwiftGD library. This PR adds the method `drawImage(_ image: Image, at: Point)` on `Image` to draw another image into it. Additional parameters of `gdImageCopy` have been omitted because it's simpler to just use the existing `cropped` function.